### PR TITLE
Done: Delete-Endpoint-#39

### DIFF
--- a/backend/src/main/java/com/tourplanner/controller/TourController.java
+++ b/backend/src/main/java/com/tourplanner/controller/TourController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.bind.annotation.DeleteMapping;
 
 import java.util.List;
 
@@ -48,5 +49,11 @@ public class TourController {
     @PutMapping("/{id}")
     public TourDto update(@PathVariable long id, @Valid @RequestBody TourDto tour) {
         return tourService.update(id, tour);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable long id) {
+        tourService.delete(id);
     }
 }

--- a/backend/src/main/java/com/tourplanner/service/TourServiceImpl.java
+++ b/backend/src/main/java/com/tourplanner/service/TourServiceImpl.java
@@ -54,4 +54,13 @@ public class TourServiceImpl implements TourService {
         Tour saved = tourRepository.save(entity);
         return tourMapper.toDto(saved);
     }
+
+    @Override
+    @Transactional
+    public void delete(long id) {
+        if (!tourRepository.existsById(id)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        }
+        tourRepository.deleteById(id);
+    }
 }


### PR DESCRIPTION
- [X] Ein DELETE /api/tours/1 löscht den Datensatz und gibt HTTP 204 (No Content) zurück

- [X] Ein anschließendes GET /api/tours enthält die gelöschte Tour nicht mehr

- [X] Ein DELETE /api/tours/9999 auf eine nicht-existierende ID liefert HTTP 404

Delete Methode hinzugefügt, Logik umgesetzt und Endpoint angelegt.